### PR TITLE
IPv6 healthcheck failing fix

### DIFF
--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -46,7 +46,7 @@ if [ -r "${CONFIG_FILE}" ]; then
 fi
 
 addr="${ROCKET_ADDRESS}"
-if [ -z "${addr}" ] || [ "${addr}" = '0.0.0.0' ] || [ "${addr}" = '::' ]; then
+if [ -z "${addr}" ] || [ "${addr}" = '0.0.0.0' ] || [ "${addr}" = '::0' ]; then
     addr='localhost'
 fi
 base_path="$(get_base_path "${DOMAIN}")"


### PR DESCRIPTION
When I enabled IPv6 I later realized that the healthcheck of the container was failing:
`Up 32 minutes (unhealthy) `

Setting `ROCKET_ADDRESS=::` in docker-compose gives the error: 
```
$ docker-compose up -d --build
services.vaultwarden.environment.13 must be a string
```

So to be able to use IPv6 ROCKET_ADDRESS needs to be set to `ROCKET_ADDRESS=::0`

In bash `::` doesn't equal `::0` and hence my healthcheck is failing, since it isn't rewritten to localhost